### PR TITLE
Fix usages of Object.assign() that overwrote default props or propTypes of other classes

### DIFF
--- a/example/index.jsx
+++ b/example/index.jsx
@@ -3,7 +3,7 @@
 import React from 'react';
 import {render} from 'react-dom';
 import './style.scss';
-// import {fabric} from 'fabric-webpack';
+// import {fabric} from 'fabric';
 
 import Canvas from 'react-fabricjs/Canvas';
 import Circle from 'react-fabricjs/shape/Circle';

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   },
   "dependencies": {
     "deep-diff": "~0.3.3",
-    "fabric-webpack": "~1.6.0-rc.1",
+    "fabric": "^1.6.6",
     "object-assign": "~4.0.1"
   },
   "devDependencies": {

--- a/src/Canvas.jsx
+++ b/src/Canvas.jsx
@@ -47,7 +47,7 @@ export default class Canvas extends StaticCanvas {
 	}
 }
 
-Canvas.propTypes = Object.assign(StaticCanvas.propTypes, {
+Canvas.propTypes = Object.assign({}, StaticCanvas.propTypes, {
 	uniScaleTransform: PropTypes.bool,
 	centeredScaling: PropTypes.bool,
 	centeredRotation: PropTypes.bool,
@@ -69,7 +69,7 @@ Canvas.propTypes = Object.assign(StaticCanvas.propTypes, {
 	isDrawingMode: PropTypes.bool,
 });
 
-Canvas.defaultProps = Object.assign(StaticCanvas.defaultProps, {
+Canvas.defaultProps = Object.assign({}, StaticCanvas.defaultProps, {
 	uniScaleTransform: false,
 	centeredScaling: false,
 	centeredRotation: false,

--- a/src/Color.js
+++ b/src/Color.js
@@ -1,4 +1,4 @@
 'use strict';
 
-import {fabric} from 'fabric-webpack';
+import {fabric} from 'fabric';
 export default fabric.Color;

--- a/src/IText.jsx
+++ b/src/IText.jsx
@@ -97,7 +97,7 @@ export default class IText extends Text {
 }
 IText.fromObject = (object) => fabric.IText.fromObject(object);
 
-IText.propTypes = Object.assign(Text.propTypes, {
+IText.propTypes = Object.assign({}, Text.propTypes, {
 	selectionStart: PropTypes.number,
 	selectionEnd: PropTypes.number,
 	selectionColor: PropTypes.string,
@@ -112,7 +112,7 @@ IText.propTypes = Object.assign(Text.propTypes, {
 	caching: PropTypes.bool,
 });
 
-IText.defaultProps = Object.assign(Text.defaultProps, {
+IText.defaultProps = Object.assign({}, Text.defaultProps, {
 	type: 'i-text',
 	selectionStart: 0,
 	selectionEnd: 0,

--- a/src/IText.jsx
+++ b/src/IText.jsx
@@ -2,7 +2,7 @@
 
 import {PropTypes} from 'react';
 import Text from './Text';
-import {fabric} from 'fabric-webpack';
+import {fabric} from 'fabric';
 
 export default class IText extends Text {
 	constructor(props, context) {

--- a/src/Image.jsx
+++ b/src/Image.jsx
@@ -2,7 +2,7 @@
 
 import {PropTypes} from 'react';
 import FabricObject from './base/Object.jsx';
-import {fabric} from 'fabric-webpack';
+import {fabric} from 'fabric';
 
 export default class Image extends FabricObject {
 	constructor(props, context) {

--- a/src/Image.jsx
+++ b/src/Image.jsx
@@ -69,14 +69,14 @@ Image.attribute = fabric.Image.ATTRIBUTE_NAMES;
 Image.async = true;
 Image.pngCompression = 1;
 
-Image.propTypes = Object.assign(FabricObject.propTypes, {
+Image.propTypes = Object.assign({}, FabricObject.propTypes, {
 	crossOrigin: PropTypes.oneOf(['', 'anonymous', 'use-credentials']),
 	alignX: PropTypes.oneOf(['none', 'mid', 'min', 'max']),
 	alignY: PropTypes.oneOf(['none', 'mid', 'min', 'max']),
 	meetOrSlice: PropTypes.oneOf(['meet', 'slice']),
 });
 
-Image.defaultProps = Object.assign(FabricObject.defaultProps, {
+Image.defaultProps = Object.assign({}, FabricObject.defaultProps, {
 	type: 'image',
 	crossOrigin: '',
 	alignX: 'none',

--- a/src/ImageFilters.js
+++ b/src/ImageFilters.js
@@ -1,6 +1,6 @@
 'use strict';
 
-import {fabric} from 'fabric-webpack';
+import {fabric} from 'fabric';
 
 export const BaseFilter = fabric.Image.filters.BaseFilter;
 export const Brightness = fabric.Image.filters.Brightness;

--- a/src/StaticCanvas.jsx
+++ b/src/StaticCanvas.jsx
@@ -277,19 +277,23 @@ export default class StaticCanvas extends React.Component {
 		return (
 			<div>
 				<canvas id={id} width={this.props.width} height={this.props.height}/>
-				{
-					this.state.canvas &&
-					React.Children.map(
-						children,
-						(child, i) => child && React.cloneElement(child, {
-							ref: c => {
-								if (c) {
-									this.ref[child.ref||`layer${i}`] = c;
-								}
-							},
-						})
-					)
-				}
+
+				<div>
+					{
+						this.state.canvas &&
+						React.Children.map(
+							children,
+							(child, i) => child && React.cloneElement(child, {
+								ref: c => {
+									if (c) {
+										this.ref[child.ref||`layer${i}`] = c;
+									}
+								},
+							})
+						)
+					}
+				</div>
+
 			</div>
 		);
 

--- a/src/StaticCanvas.jsx
+++ b/src/StaticCanvas.jsx
@@ -185,13 +185,22 @@ export default class StaticCanvas extends React.Component {
 
 					const key = child.ref ? child.ref : `layer${i}`;
 					const ref = this.ref[key];
-					ref.draw(obj => this.add(obj));
+					ref.draw(obj => {
+						// because this callback is called asynchronously, if multiple updates occur in quick
+						// succession then it's possible we'll attempt to remove an object (below) before it has been
+						// added (here) - the result of which is duplicate objects on the canvas
+						if (!obj.doNotAdd) {
+							this.add(obj);
+						}
+					});
 				}
 			);
 
 			Object.keys(this.prevRef).forEach(key => {
-				const ref = this.prevRef[key];
-				this.remove(ref.getObject());
+				const object = this.prevRef[key].getObject();
+				// in case this object hasn't actually been added yet, set a flag so that we don't add it later
+				object.doNotAdd = true;
+				this.remove(object);
 			});
 		}
 

--- a/src/StaticCanvas.jsx
+++ b/src/StaticCanvas.jsx
@@ -1,7 +1,7 @@
 'use strict';
 
 import React, { PropTypes } from 'react';
-import {fabric} from 'fabric-webpack';
+import {fabric} from 'fabric';
 import diff from 'deep-diff';
 import collection from './mixin/collection.js';
 import observable from './mixin/observable.js';

--- a/src/Text.jsx
+++ b/src/Text.jsx
@@ -42,7 +42,7 @@ Text.defaultSvgFontSize = fabric.Text.DEFAULT_SVG_FONT_SIZE;
 Text.fromElement = (element, options) => fabric.Text.fromElement(element, options);
 Text.fromObject = (object) => fabric.Text.fromObject(object);
 
-Text.propTypes = Object.assign(FabricObject.propTypes, {
+Text.propTypes = Object.assign({}, FabricObject.propTypes, {
 	fontSize: PropTypes.number,
 	fontWeight: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
 	fontFamily: PropTypes.string,
@@ -53,7 +53,7 @@ Text.propTypes = Object.assign(FabricObject.propTypes, {
 	textBackgroundColor: PropTypes.string,
 });
 
-Text.defaultProps = Object.assign(FabricObject.defaultProps, {
+Text.defaultProps = Object.assign({}, FabricObject.defaultProps, {
 	type: 'text',
 	stateProperties: FabricObject.defaultProps.stateProperties.concat(['fontFamily',
 		'fontWeight',

--- a/src/Text.jsx
+++ b/src/Text.jsx
@@ -2,7 +2,7 @@
 
 import {PropTypes} from 'react';
 import FabricObject from './base/Object.jsx';
-import {fabric} from 'fabric-webpack';
+import {fabric} from 'fabric';
 
 export default class Text extends FabricObject {
 	constructor(props, context) {

--- a/src/base/Object.jsx
+++ b/src/base/Object.jsx
@@ -1,7 +1,7 @@
 'use strict';
 
 import React, { PropTypes } from 'react';
-import {fabric} from 'fabric-webpack';
+import {fabric} from 'fabric';
 import diff from 'deep-diff';
 import observable from '../mixin/observable.js';
 

--- a/src/shape/Circle.jsx
+++ b/src/shape/Circle.jsx
@@ -52,13 +52,13 @@ Circle.fromElement = (element, options) => fabric.Circle.fromElement(element, op
 Circle.fromObject = (object) => fabric.Circle.fromObject(object);
 Circle.attribute = fabric.Circle.ATTRIBUTE_NAMES;
 
-Circle.propTypes = Object.assign(FabricObject.propTypes, {
+Circle.propTypes = Object.assign({}, FabricObject.propTypes, {
 	endAngle: PropTypes.number,
 	radius: PropTypes.number,
 	startAngle: PropTypes.number,
 });
 
-Circle.defaultProps = Object.assign(FabricObject.defaultProps, {
+Circle.defaultProps = Object.assign({}, FabricObject.defaultProps, {
 	endAngle: 2 * PI,
 	radius: 0,
 	startAngle: 0,

--- a/src/shape/Circle.jsx
+++ b/src/shape/Circle.jsx
@@ -2,7 +2,7 @@
 
 import React, {PropTypes} from 'react';
 import FabricObject from '../base/Object.jsx';
-import {fabric} from 'fabric-webpack';
+import {fabric} from 'fabric';
 const PI = Math.PI;
 
 export default class Circle extends FabricObject {

--- a/src/shape/Circle.jsx
+++ b/src/shape/Circle.jsx
@@ -41,11 +41,6 @@ export default class Circle extends FabricObject {
 
 		super.draw(object, cb);
 	}
-
-	render() {
-		return <div />;
-	}
-
 }
 
 Circle.fromElement = (element, options) => fabric.Circle.fromElement(element, options);

--- a/src/shape/Ellipse.jsx
+++ b/src/shape/Ellipse.jsx
@@ -44,12 +44,12 @@ Ellipse.fromElement = (element, options) => fabric.Ellipse.fromElement(element, 
 Ellipse.fromObject = (object) => fabric.Ellipse.fromObject(object);
 Ellipse.attribute = fabric.Ellipse.ATTRIBUTE_NAMES;
 
-Ellipse.propTypes = Object.assign(FabricObject.propTypes, {
+Ellipse.propTypes = Object.assign({}, FabricObject.propTypes, {
 	rx: PropTypes.number,
 	ry: PropTypes.number,
 });
 
-Ellipse.defaultProps = Object.assign(FabricObject.defaultProps, {
+Ellipse.defaultProps = Object.assign({}, FabricObject.defaultProps, {
 	rx: 0,
 	ry: 0,
 	type: 'ellipse',

--- a/src/shape/Ellipse.jsx
+++ b/src/shape/Ellipse.jsx
@@ -2,7 +2,7 @@
 
 import {PropTypes} from 'react';
 import FabricObject from '../base/Object.jsx';
-import {fabric} from 'fabric-webpack';
+import {fabric} from 'fabric';
 
 export default class Ellipse extends FabricObject {
 	constructor(props, context) {

--- a/src/shape/Group.jsx
+++ b/src/shape/Group.jsx
@@ -2,7 +2,7 @@
 
 import {PropTypes} from 'react';
 import FabricObject from '../base/Object.jsx';
-import {fabric} from 'fabric-webpack';
+import {fabric} from 'fabric';
 
 export default class Group extends FabricObject {
 	constructor(props, context) {

--- a/src/shape/Group.jsx
+++ b/src/shape/Group.jsx
@@ -51,8 +51,8 @@ export default class Group extends FabricObject {
 Group.fromObject = (object) => fabric.Group.fromObject(object);
 Group.async = true;
 
-Group.propTypes = FabricObject.propTypes;
-Group.defaultProps = Object.assign(FabricObject.defaultProps, {
+Group.propTypes = Object.assign({}, FabricObject.propTypes);
+Group.defaultProps = Object.assign({}, FabricObject.defaultProps, {
 	strokeWidth: 0,
 	type: 'group',
 });

--- a/src/shape/Line.jsx
+++ b/src/shape/Line.jsx
@@ -41,14 +41,14 @@ Line.fromElement = (element, options) => fabric.Line.fromElement(element, option
 Line.fromObject = (object) => fabric.Line.fromObject(object);
 Line.attribute = fabric.Line.ATTRIBUTE_NAMES;
 
-Line.propTypes = Object.assign(FabricObject.propTypes, {
+Line.propTypes = Object.assign({}, FabricObject.propTypes, {
 	x1: PropTypes.number,
 	y1: PropTypes.number,
 	x2: PropTypes.number,
 	y2: PropTypes.number,
 });
 
-Line.defaultProps = Object.assign(FabricObject.defaultProps, {
+Line.defaultProps = Object.assign({}, FabricObject.defaultProps, {
 	type: 'line',
 	x1: 0,
 	y1: 0,

--- a/src/shape/Line.jsx
+++ b/src/shape/Line.jsx
@@ -2,7 +2,7 @@
 
 import {PropTypes} from 'react';
 import FabricObject from '../base/Object.jsx';
-import {fabric} from 'fabric-webpack';
+import {fabric} from 'fabric';
 
 export default class Line extends FabricObject {
 	constructor(props, context) {

--- a/src/shape/Path.jsx
+++ b/src/shape/Path.jsx
@@ -51,13 +51,13 @@ Path.fromElement = (element, callback, options) => fabric.Path.fromElement(eleme
 Path.fromObject = (object, callback) => fabric.Path.fromObject(object, callback);
 Path.attribute = fabric.Path.ATTRIBUTE_NAMES;
 
-Path.propTypes = Object.assign(FabricObject.propTypes, {
+Path.propTypes = Object.assign({}, FabricObject.propTypes, {
 	path: PropTypes.oneOfType([PropTypes.array, PropTypes.string]),
 	minX: PropTypes.number,
 	minY: PropTypes.number,
 });
 
-Path.defaultProps = Object.assign(FabricObject.defaultProps, {
+Path.defaultProps = Object.assign({}, FabricObject.defaultProps, {
 	type: 'path',
 	path: null,
 	minX: 0,

--- a/src/shape/Path.jsx
+++ b/src/shape/Path.jsx
@@ -2,7 +2,7 @@
 
 import {PropTypes} from 'react';
 import FabricObject from '../base/Object.jsx';
-import {fabric} from 'fabric-webpack';
+import {fabric} from 'fabric';
 
 export default class Path extends FabricObject {
 	constructor(props, context) {

--- a/src/shape/PathGroup.jsx
+++ b/src/shape/PathGroup.jsx
@@ -65,7 +65,7 @@ PathGroup.fromElement = (element, callback, options) => fabric.PathGroup.fromEle
 PathGroup.fromObject = (object, callback) => fabric.PathGroup.fromObject(object, callback);
 PathGroup.attribute = fabric.PathGroup.ATTRIBUTE_NAMES;
 
-PathGroup.defaultProps = Object.assign(Path.defaultProps, {
+PathGroup.defaultProps = Object.assign({}, Path.defaultProps, {
 	type: 'path-group',
 	fill: '',
 });

--- a/src/shape/PathGroup.jsx
+++ b/src/shape/PathGroup.jsx
@@ -2,7 +2,7 @@
 
 import {PropTypes} from 'react';
 import Path from './Path';
-import {fabric} from 'fabric-webpack';
+import {fabric} from 'fabric';
 
 export default class PathGroup extends Path {
 	constructor(props, context) {

--- a/src/shape/Polygon.jsx
+++ b/src/shape/Polygon.jsx
@@ -41,13 +41,13 @@ Polygon.fromElement = (element, options) => fabric.Polygon.fromElement(element, 
 Polygon.fromObject = (object) => fabric.Polygon.fromObject(object);
 Polygon.attribute = fabric.Polygon.ATTRIBUTE_NAMES;
 
-Polygon.propTypes = Object.assign(FabricObject.propTypes, {
+Polygon.propTypes = Object.assign({}, FabricObject.propTypes, {
 	points: PropTypes.array,
 	minX: PropTypes.number,
 	minY: PropTypes.number,
 });
 
-Polygon.defaultProps = Object.assign(FabricObject.defaultProps, {
+Polygon.defaultProps = Object.assign({}, FabricObject.defaultProps, {
 	type: 'polygon',
 	points: null,
 	minX: 0,

--- a/src/shape/Polygon.jsx
+++ b/src/shape/Polygon.jsx
@@ -2,7 +2,7 @@
 
 import {PropTypes} from 'react';
 import FabricObject from '../base/Object.jsx';
-import {fabric} from 'fabric-webpack';
+import {fabric} from 'fabric';
 
 export default class Polygon extends FabricObject {
 	constructor(props, context) {

--- a/src/shape/Polyline.jsx
+++ b/src/shape/Polyline.jsx
@@ -2,7 +2,7 @@
 
 import {PropTypes} from 'react';
 import FabricObject from '../base/Object.jsx';
-import {fabric} from 'fabric-webpack';
+import {fabric} from 'fabric';
 
 export default class Polyline extends FabricObject {
 	constructor(props, context) {

--- a/src/shape/Polyline.jsx
+++ b/src/shape/Polyline.jsx
@@ -39,13 +39,13 @@ Polyline.fromElement = (element, options) => fabric.Polyline.fromElement(element
 Polyline.fromObject = (object) => fabric.Polyline.fromObject(object);
 Polyline.attribute = fabric.Polyline.ATTRIBUTE_NAMES;
 
-Polyline.propTypes = Object.assign(FabricObject.propTypes, {
+Polyline.propTypes = Object.assign({}, FabricObject.propTypes, {
 	points: PropTypes.array,
 	minX: PropTypes.number,
 	minY: PropTypes.number,
 });
 
-Polyline.defaultProps = Object.assign(FabricObject.defaultProps, {
+Polyline.defaultProps = Object.assign({}, FabricObject.defaultProps, {
 	type: 'polyline',
 	points: null,
 	minX: 0,

--- a/src/shape/Rect.jsx
+++ b/src/shape/Rect.jsx
@@ -39,12 +39,12 @@ Rect.fromElement = (element, options) => fabric.Rect.fromElement(element, option
 Rect.fromObject = (object) => fabric.Rect.fromObject(object);
 Rect.attribute = fabric.Rect.ATTRIBUTE_NAMES;
 
-Rect.propTypes = Object.assign(FabricObject.propTypes, {
+Rect.propTypes = Object.assign({}, FabricObject.propTypes, {
 	rx: PropTypes.number,
 	ry: PropTypes.number,
 });
 
-Rect.defaultProps = Object.assign(FabricObject.defaultProps, {
+Rect.defaultProps = Object.assign({}, FabricObject.defaultProps, {
 	type: 'rect',
 	rx: 0,
 	ry: 0,

--- a/src/shape/Rect.jsx
+++ b/src/shape/Rect.jsx
@@ -2,7 +2,7 @@
 
 import {PropTypes} from 'react';
 import FabricObject from '../base/Object.jsx';
-import {fabric} from 'fabric-webpack';
+import {fabric} from 'fabric';
 
 export default class Rect extends FabricObject {
 	constructor(props, context) {

--- a/src/shape/Triangle.jsx
+++ b/src/shape/Triangle.jsx
@@ -2,7 +2,7 @@
 
 // import {PropTypes} from 'react';
 import FabricObject from '../base/Object.jsx';
-import {fabric} from 'fabric-webpack';
+import {fabric} from 'fabric';
 
 export default class Triangle extends FabricObject {
 	constructor(props, context) {

--- a/src/shape/Triangle.jsx
+++ b/src/shape/Triangle.jsx
@@ -35,7 +35,7 @@ export default class Triangle extends FabricObject {
 
 Triangle.fromObject = (object) => fabric.Triangle.fromObject(object);
 
-Triangle.propTypes = FabricObject.propTypes;
-Triangle.defaultProps = Object.assign(FabricObject.defaultProps, {
+Triangle.propTypes = Object.assign({}, FabricObject.propTypes);
+Triangle.defaultProps = Object.assign({}, FabricObject.defaultProps, {
 	type: 'triangle',
 });


### PR DESCRIPTION
Hi,

I found there was an issue with code like this:

``` javascript
Circle.defaultProps = Object.assign(FabricObject.defaultProps, {...})
```

which actually copied the new defaults into the other object (`FabricObject.defaultProps` in the above example). Another example is if you inspect `Circle.defaultProps` at runtime, you'll see it has `type: "i-text"` and other non-circle-related properties. The same applies to `PropTypes`.

While I was fixing this, I also updated to fabric `1.6.6` - by switching from the `fabric-webpack` package to `fabric`. Not sure why those two are both in npm but there is no actual difference between them - apart from that `fabric-webpack` is out of date.

Then one further thing - the version of react-fabricjs available in npm (version `0.1.6`) had two code changes that don't appear to have been pushed to the github repo - and without them I was getting the error `Failed to execute 'insertBefore' on 'Node': The node before which the new node is to be inserted is not a child of this node` from React. So I've committed them in this PR too.
