### PR TITLE
Fix set width on componentWillReceiveProps

### DIFF
--- a/src/StaticCanvas.jsx
+++ b/src/StaticCanvas.jsx
@@ -156,7 +156,7 @@ export default class StaticCanvas extends React.Component {
 			this.state.canvas.setHeight(nextProps.height);
 		}
 		if (this.props.width !== nextProps.width) {
-			this.state.canvas.setHeight(nextProps.width);
+			this.state.canvas.setWidth(nextProps.width);
 		}
 
 		if (diff(this.props.overlayColor, nextProps.overlayColor)) {


### PR DESCRIPTION
Fix StaticCanvas.js to allow StaticCanvas object to properly set width on componentWillReceiveProps.

Old behavior:  Incorrectly assign width to height on Class canvas-container div and upper-canvas canvas DOM elements, preventing proper placement & control of fabricjs objects on Canvas.

New behavior:  Class canvas-container div and upper-canvas canvas DOM elements properly get width values when set on Canvas.

